### PR TITLE
Add an option to force use of auto_ptr for legacy STL implementations.

### DIFF
--- a/src/unique_ptr.h
+++ b/src/unique_ptr.h
@@ -22,11 +22,10 @@
 
 #include <memory>
 
-#if __cplusplus >= 201103L
-// C++11
+#if __cplusplus >= 201103L && !defined(OPEN_VCDIFF_USE_AUTO_PTR) // C++11
 #define UNIQUE_PTR std::unique_ptr
 #else
 #define UNIQUE_PTR std::auto_ptr
-#endif
+#endif  // __cplusplus >= 201103L && !defined(OPEN_VCDIFF_USE_AUTO_PTR)
 
 #endif  // OPEN_VCDIFF_UNIQUE_PTR_H_


### PR DESCRIPTION
With this, we can force usage of auto_ptr when using a recent compiler with an old STL implementation.
This is meant as a temporary workaround until we provide a proper update to open-vcdiff.