### PR TITLE
Fix MSVC warnings about implicit value truncations.

### DIFF
--- a/src/addrcache.cc
+++ b/src/addrcache.cc
@@ -43,8 +43,8 @@ namespace open_vcdiff {
 //     Because the mode is expressed as a byte value,
 //     near_cache_size + same_cache_size should not exceed 254.
 //
-VCDiffAddressCache::VCDiffAddressCache(int near_cache_size,
-                                       int same_cache_size)
+VCDiffAddressCache::VCDiffAddressCache(unsigned char near_cache_size,
+                                       unsigned char same_cache_size)
     : near_cache_size_(near_cache_size),
       same_cache_size_(same_cache_size),
       next_slot_(0) { }
@@ -71,22 +71,10 @@ VCDiffAddressCache::VCDiffAddressCache()
 bool VCDiffAddressCache::Init() {
   // The mode is expressed as a byte value, so there is only room for 256 modes,
   // including the two non-cached modes (SELF and HERE).  Do not allow a larger
-  // number of modes to be defined.  We do a separate sanity check for
-  // near_cache_size_ and same_cache_size_ because adding them together can
-  // cause an integer overflow if each is set to, say, INT_MAX.
-  if ((near_cache_size_ > (VCD_MAX_MODES - 2)) || (near_cache_size_ < 0)) {
-    VCD_ERROR << "Near cache size " << near_cache_size_ << " is invalid"
-              << VCD_ENDL;
-    return false;
-  }
-  if ((same_cache_size_ > (VCD_MAX_MODES - 2)) || (same_cache_size_ < 0)) {
-    VCD_ERROR << "Same cache size " << same_cache_size_ << " is invalid"
-              << VCD_ENDL;
-    return false;
-  }
+  // number of modes to be defined.
   if ((near_cache_size_ + same_cache_size_) > VCD_MAX_MODES - 2) {
-    VCD_ERROR << "Using near cache size " << near_cache_size_
-              << " and same cache size " << same_cache_size_
+    VCD_ERROR << "Using near cache size " << static_cast<int>(near_cache_size_)
+              << " and same cache size " << static_cast<int>(same_cache_size_)
               << " would exceed maximum number of COPY modes ("
               << VCD_MAX_MODES << ")" << VCD_ENDL;
     return false;
@@ -175,7 +163,8 @@ unsigned char VCDiffAddressCache::EncodeAddress(VCDAddress address,
       // to the address stream instead of a variable-length integer.
       UpdateCache(address);
       *encoded_addr = same_cache_pos % 256;
-      return FirstSameMode() + (same_cache_pos / 256);  // SAME mode
+      return FirstSameMode() +
+          static_cast<unsigned char>(same_cache_pos / 256);  // SAME mode
     }
   }
 
@@ -193,7 +182,7 @@ unsigned char VCDiffAddressCache::EncodeAddress(VCDAddress address,
   }
 
   // Try using the NEAR cache
-  for (int i = 0; i < near_cache_size(); ++i) {
+  for (unsigned char i = 0; i < near_cache_size(); ++i) {
     const VCDAddress near_encoded_address = address - NearAddress(i);
     if ((near_encoded_address >= 0) &&
         (near_encoded_address < best_encoded_address)) {

--- a/src/addrcache.h
+++ b/src/addrcache.h
@@ -37,10 +37,11 @@ namespace open_vcdiff {
 class VCDiffAddressCache {
  public:
   // The default cache sizes specified in the RFC
-  static const int kDefaultNearCacheSize = 4;
-  static const int kDefaultSameCacheSize = 3;
+  static const unsigned char kDefaultNearCacheSize = 4;
+  static const unsigned char kDefaultSameCacheSize = 3;
 
-  VCDiffAddressCache(int near_cache_size, int same_cache_size);
+  VCDiffAddressCache(unsigned char near_cache_size,
+                     unsigned char same_cache_size);
 
   // This version of the constructor uses the default values
   // kDefaultNearCacheSize and kDefaultSameCacheSize.
@@ -55,9 +56,9 @@ class VCDiffAddressCache {
   //
   bool Init();
 
-  int near_cache_size() const { return near_cache_size_; }
+  unsigned char near_cache_size() const { return near_cache_size_; }
 
-  int same_cache_size() const { return same_cache_size_; }
+  unsigned char same_cache_size() const { return same_cache_size_; }
 
   // Returns the first mode number that represents one of the NEAR modes.
   // The number of NEAR modes is near_cache_size.  Each NEAR mode refers to
@@ -196,11 +197,11 @@ class VCDiffAddressCache {
 
  private:
   // The number of addresses to be kept in the NEAR cache.
-  const int near_cache_size_;
+  const unsigned char near_cache_size_;
   // The number of 256-byte blocks to store in the SAME cache.
-  const int same_cache_size_;
+  const unsigned char same_cache_size_;
   // The next position in the NEAR cache to which an address will be written.
-  int       next_slot_;
+  int next_slot_;
   // NEAR cache contents
   std::vector<VCDAddress> near_addresses_;
   // SAME cache contents

--- a/src/addrcache_test.cc
+++ b/src/addrcache_test.cc
@@ -139,61 +139,39 @@ TEST_F(VCDiffAddressCacheTest, ZeroCacheSizes) {
   EXPECT_TRUE(zero_cache.Init());
 }
 
-TEST_F(VCDiffAddressCacheTest, NegativeCacheSizes) {
-  VCDiffAddressCache negative_cache(-1, -1);   // The constructor must not fail
-  EXPECT_FALSE(negative_cache.Init());
-}
-
-TEST_F(VCDiffAddressCacheTest, OnlySameCacheSizeIsNegative) {
-  VCDiffAddressCache negative_cache(0, -1);   // The constructor must not fail
-  EXPECT_FALSE(negative_cache.Init());
-}
-
-TEST_F(VCDiffAddressCacheTest, ExtremePositiveCacheSizes) {
-  // The constructor must not fail
-  VCDiffAddressCache int_max_cache(INT_MAX, INT_MAX);
-  EXPECT_FALSE(int_max_cache.Init());
-}
-
-TEST_F(VCDiffAddressCacheTest, ExtremeNegativeCacheSizes) {
-  // The constructor must not fail
-  VCDiffAddressCache int_min_cache(INT_MIN, INT_MIN);
-  EXPECT_FALSE(int_min_cache.Init());
-}
-
 // VCD_MAX_MODES is the maximum number of modes, including SAME and HERE modes.
 // So neither the SAME cache nor the HERE cache can be larger than
 // (VCD_MAX_MODES - 2).
 TEST_F(VCDiffAddressCacheTest, NearCacheSizeIsTooBig) {
-  VCDiffAddressCache negative_cache(VCD_MAX_MODES - 1, 0);
-  EXPECT_FALSE(negative_cache.Init());
+  VCDiffAddressCache cache(VCD_MAX_MODES - 1, 0);
+  EXPECT_FALSE(cache.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, SameCacheSizeIsTooBig) {
-  VCDiffAddressCache negative_cache(0, VCD_MAX_MODES - 1);
-  EXPECT_FALSE(negative_cache.Init());
+  VCDiffAddressCache cache(0, VCD_MAX_MODES - 1);
+  EXPECT_FALSE(cache.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, CombinedSizesAreTooBig) {
-  VCDiffAddressCache negative_cache((VCD_MAX_MODES / 2),
-                                    (VCD_MAX_MODES / 2) - 1);
-  EXPECT_FALSE(negative_cache.Init());
+  VCDiffAddressCache cache1((VCD_MAX_MODES / 2), (VCD_MAX_MODES / 2) - 1);
+  EXPECT_FALSE(cache1.Init());
+  VCDiffAddressCache cache2(VCD_MAX_MODES - 1, VCD_MAX_MODES - 1);
+  EXPECT_FALSE(cache2.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, MaxLegalNearCacheSize) {
-  VCDiffAddressCache negative_cache(VCD_MAX_MODES - 2, 0);
-  EXPECT_TRUE(negative_cache.Init());
+  VCDiffAddressCache cache(VCD_MAX_MODES - 2, 0);
+  EXPECT_TRUE(cache.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, MaxLegalSameCacheSize) {
-  VCDiffAddressCache negative_cache(0, VCD_MAX_MODES - 2);
-  EXPECT_TRUE(negative_cache.Init());
+  VCDiffAddressCache cache(0, VCD_MAX_MODES - 2);
+  EXPECT_TRUE(cache.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, MaxLegalCombinedSizes) {
-  VCDiffAddressCache negative_cache((VCD_MAX_MODES / 2) - 1,
-                                    (VCD_MAX_MODES / 2) - 1);
-  EXPECT_TRUE(negative_cache.Init());
+  VCDiffAddressCache cache((VCD_MAX_MODES / 2) - 1, (VCD_MAX_MODES / 2) - 1);
+  EXPECT_TRUE(cache.Init());
 }
 
 TEST_F(VCDiffAddressCacheTest, DestroyWithoutInitialization) {

--- a/src/encodetable.cc
+++ b/src/encodetable.cc
@@ -67,8 +67,8 @@ VCDiffCodeTableWriter::VCDiffCodeTableWriter(bool interleaved)
 
 VCDiffCodeTableWriter::VCDiffCodeTableWriter(
     bool interleaved,
-    int near_cache_size,
-    int same_cache_size,
+    unsigned char near_cache_size,
+    unsigned char same_cache_size,
     const VCDiffCodeTableData& code_table_data,
     unsigned char max_mode)
     : max_mode_(max_mode),
@@ -189,11 +189,9 @@ void VCDiffCodeTableWriter::EncodeInstruction(VCDiffInstructionType inst,
     }
     OpcodeOrNone compound_opcode = kNoOpcode;
     if (size <= UCHAR_MAX) {
-      compound_opcode =
-          instruction_map_->LookupSecondOpcode(last_opcode,
-                                               inst,
-                                               static_cast<unsigned char>(size),
-                                               mode);
+      compound_opcode = instruction_map_->LookupSecondOpcode(
+          last_opcode, static_cast<unsigned char>(inst),
+          static_cast<unsigned char>(size), mode);
       if (compound_opcode != kNoOpcode) {
         instructions_and_sizes_[last_opcode_index_] =
             static_cast<unsigned char>(compound_opcode);
@@ -202,10 +200,8 @@ void VCDiffCodeTableWriter::EncodeInstruction(VCDiffInstructionType inst,
       }
     }
     // Try finding a compound opcode with size 0.
-    compound_opcode = instruction_map_->LookupSecondOpcode(last_opcode,
-                                                           inst,
-                                                           0,
-                                                           mode);
+    compound_opcode = instruction_map_->LookupSecondOpcode(
+        last_opcode, static_cast<unsigned char>(inst), 0, mode);
     if (compound_opcode != kNoOpcode) {
       instructions_and_sizes_[last_opcode_index_] =
           static_cast<unsigned char>(compound_opcode);
@@ -217,9 +213,9 @@ void VCDiffCodeTableWriter::EncodeInstruction(VCDiffInstructionType inst,
   OpcodeOrNone opcode = kNoOpcode;
   if (size <= UCHAR_MAX) {
     opcode =
-        instruction_map_->LookupFirstOpcode(inst,
-                                            static_cast<unsigned char>(size),
-                                            mode);
+        instruction_map_->LookupFirstOpcode(
+            static_cast<unsigned char>(inst), static_cast<unsigned char>(size),
+            mode);
     if (opcode != kNoOpcode) {
       instructions_and_sizes_.push_back(static_cast<char>(opcode));
       last_opcode_index_ = static_cast<int>(instructions_and_sizes_.size() - 1);
@@ -227,7 +223,8 @@ void VCDiffCodeTableWriter::EncodeInstruction(VCDiffInstructionType inst,
     }
   }
   // There should always be an opcode with size 0.
-  opcode = instruction_map_->LookupFirstOpcode(inst, 0, mode);
+  opcode = instruction_map_->LookupFirstOpcode(
+      static_cast<unsigned char>(inst), 0, mode);
   if (opcode == kNoOpcode) {
     VCD_DFATAL << "No matching opcode found for inst " << inst
                << ", mode " << mode << ", size 0" << VCD_ENDL;

--- a/src/encodetable.h
+++ b/src/encodetable.h
@@ -65,8 +65,8 @@ class VCDiffCodeTableWriter : public CodeTableWriterInterface {
   // the file has been decoded.
   //
   VCDiffCodeTableWriter(bool interleaved,
-                        int near_cache_size,
-                        int same_cache_size,
+                        unsigned char near_cache_size,
+                        unsigned char same_cache_size,
                         const VCDiffCodeTableData& code_table_data,
                         unsigned char max_mode);
 

--- a/src/instruction_map.cc
+++ b/src/instruction_map.cc
@@ -163,7 +163,7 @@ VCDiffInstructionMap::VCDiffInstructionMap(
       first_instruction_map_.Add(code_table_data.inst1[opcode],
                                  code_table_data.size1[opcode],
                                  code_table_data.mode1[opcode],
-                                 opcode);
+                                 static_cast<unsigned char>(opcode));
     } else if (code_table_data.inst1[opcode] == VCD_NOOP) {
       // An unusual case where inst1 == NOOP and inst2 == ADD, RUN, or COPY.
       // This is valid under the standard, but unlikely to be used.
@@ -171,7 +171,7 @@ VCDiffInstructionMap::VCDiffInstructionMap(
       first_instruction_map_.Add(code_table_data.inst2[opcode],
                                  code_table_data.size2[opcode],
                                  code_table_data.mode2[opcode],
-                                 opcode);
+                                 static_cast<unsigned char>(opcode));
     }
   }
   // Second pass to fill up second_instruction_map_ (depends on first pass)
@@ -188,7 +188,7 @@ VCDiffInstructionMap::VCDiffInstructionMap(
                                   code_table_data.inst2[opcode],
                                   code_table_data.size2[opcode],
                                   code_table_data.mode2[opcode],
-                                  opcode);
+                                  static_cast<unsigned char>(opcode));
     }
   }
 }


### PR DESCRIPTION
Cache sizes are required to fit in an unsigned char, so make this explicit. This prevents MSVC from warning in various places that we may be truncating an int to fit in an unsigned char.

This means we need to move the enforcement tests to `VCDiffStreamingDecoderImpl::InitCustomCodeTable()`, and, `VCDiffAddressCache::Init()` can no longer fail.
This also results in moving some unittest content around.