### PR TITLE
Add a copyright header to config.h.in.

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,3 +1,17 @@
+// Copyright 2016 The open-vcdiff Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /* Defined to PROJECT_VERSION from CMakeLists.txt */
 #cmakedefine OPEN_VCDIFF_VERSION "${OPEN_VCDIFF_VERSION}"
 


### PR DESCRIPTION
This is useful for projects who want to check in the generated config.h and that check checked-in third-party code for presence of copyright headers (e.g. Chromium).