### PR TITLE
Fix 67

### DIFF
--- a/src/vcdecoder3_test.cc
+++ b/src/vcdecoder3_test.cc
@@ -118,10 +118,11 @@ TEST_F(VCDiffInterleavedDecoderTest, ChecksumDoesNotMatch) {
 }
 
 TEST_F(VCDiffInterleavedDecoderTest, ChecksumIsInvalid64BitVarint) {
-  static const char kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
-                                         0x80, 0x80, 0x80, 0x00 };
+  static const uint8_t kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
+                                            0x80, 0x80, 0x80, 0x00 };
   delta_window_header_[0] |= VCD_CHECKSUM;
-  delta_window_header_.append(kInvalidVarint, sizeof(kInvalidVarint));
+  delta_window_header_.append(reinterpret_cast<const char *>(kInvalidVarint),
+                              sizeof(kInvalidVarint));
   // Adjust delta window size to include size of invalid Varint.
   string size_of_invalid_varint;
   VarintBE<int32_t>::AppendToString(
@@ -659,10 +660,11 @@ TEST_F(VCDiffInterleavedDecoderTestByteByByte, ChecksumDoesNotMatch) {
 }
 
 TEST_F(VCDiffInterleavedDecoderTestByteByByte, ChecksumIsInvalid64BitVarint) {
-  static const char kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
-                                         0x80, 0x80, 0x80, 0x00 };
+  static const uint8_t kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
+                                            0x80, 0x80, 0x80, 0x00 };
   delta_window_header_[0] |= VCD_CHECKSUM;
-  delta_window_header_.append(kInvalidVarint, sizeof(kInvalidVarint));
+  delta_window_header_.append(reinterpret_cast<const char *>(kInvalidVarint),
+                              sizeof(kInvalidVarint));
   // Adjust delta window size to include size of invalid Varint.
   string size_of_invalid_varint;
   VarintBE<int32_t>::AppendToString(

--- a/src/vcdecoder4_test.cc
+++ b/src/vcdecoder4_test.cc
@@ -121,12 +121,12 @@ class VCDiffStandardWindowDecoderTest : public VCDiffDecoderTest {
   virtual ~VCDiffStandardWindowDecoderTest() {}
 
  private:
-  static const char kWindowBody[];
+  static const uint8_t kWindowBody[];
 };
 
 const size_t VCDiffStandardWindowDecoderTest::kWindow2Size;
 
-const char VCDiffStandardWindowDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffStandardWindowDecoderTest::kWindowBody[] = {
 // Window 1:
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
@@ -242,7 +242,8 @@ const char VCDiffStandardWindowDecoderTest::kWindowBody[] = {
 
 VCDiffStandardWindowDecoderTest::VCDiffStandardWindowDecoderTest() {
   UseStandardFileHeader();
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
 TEST_F(VCDiffStandardWindowDecoderTest, Decode) {
@@ -422,10 +423,10 @@ class VCDiffInterleavedWindowDecoderTest
   VCDiffInterleavedWindowDecoderTest();
   virtual ~VCDiffInterleavedWindowDecoderTest() {}
  private:
-  static const char kWindowBody[];
+  static const uint8_t kWindowBody[];
 };
 
-const char VCDiffInterleavedWindowDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffInterleavedWindowDecoderTest::kWindowBody[] = {
 // Window 1:
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
@@ -523,7 +524,8 @@ VCDiffInterleavedWindowDecoderTest::VCDiffInterleavedWindowDecoderTest() {
   // delta_window_header_ is left blank.  All window headers and bodies are
   // lumped together in delta_window_body_.  This means that AddChecksum()
   // cannot be used to test the checksum feature.
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
 TEST_F(VCDiffInterleavedWindowDecoderTest, Decode) {
@@ -636,14 +638,14 @@ TEST_F(VCDiffInterleavedWindowDecoderTest, OutputStringIsPreserved) {
 class VCDiffStandardCrossDecoderTest : public VCDiffDecoderTest {
  protected:
   static const char kExpectedTarget[];
-  static const char kWindowHeader[];
-  static const char kWindowBody[];
+  static const uint8_t kWindowHeader[];
+  static const uint8_t kWindowBody[];
 
   VCDiffStandardCrossDecoderTest();
   virtual ~VCDiffStandardCrossDecoderTest() {}
 };
 
-const char VCDiffStandardCrossDecoderTest::kWindowHeader[] = {
+const uint8_t VCDiffStandardCrossDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
@@ -656,7 +658,7 @@ const char VCDiffStandardCrossDecoderTest::kWindowHeader[] = {
     0x03   // length of addresses for COPYs
   };
 
-const char VCDiffStandardCrossDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffStandardCrossDecoderTest::kWindowBody[] = {
     // Data for ADD (length 7)
     'S', 'p', 'i', 'd', 'e', 'r', 's',
     // Instructions and sizes (length 6)
@@ -678,8 +680,10 @@ const char VCDiffStandardCrossDecoderTest::kExpectedTarget[] =
 
 VCDiffStandardCrossDecoderTest::VCDiffStandardCrossDecoderTest() {
   UseStandardFileHeader();
-  delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_header_.assign(reinterpret_cast<const char *>(kWindowHeader),
+                              sizeof(kWindowHeader));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
   expected_target_.assign(kExpectedTarget);
 }
 
@@ -713,11 +717,11 @@ class VCDiffInterleavedCrossDecoderTest
   virtual ~VCDiffInterleavedCrossDecoderTest() {}
 
  private:
-  static const char kWindowHeader[];
-  static const char kWindowBody[];
+  static const uint8_t kWindowHeader[];
+  static const uint8_t kWindowBody[];
 };
 
-const char VCDiffInterleavedCrossDecoderTest::kWindowHeader[] = {
+const uint8_t VCDiffInterleavedCrossDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
@@ -730,7 +734,7 @@ const char VCDiffInterleavedCrossDecoderTest::kWindowHeader[] = {
     0x00,  // length of addresses for COPYs
   };
 
-const char VCDiffInterleavedCrossDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffInterleavedCrossDecoderTest::kWindowBody[] = {
     0x01,  // VCD_ADD size 0
     0x07,  // Size of ADD (7)
     // Data for ADD (length 7)
@@ -746,8 +750,10 @@ const char VCDiffInterleavedCrossDecoderTest::kWindowBody[] = {
 
 VCDiffInterleavedCrossDecoderTest::VCDiffInterleavedCrossDecoderTest() {
   UseInterleavedFileHeader();
-  delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_header_.assign(reinterpret_cast<const char *>(kWindowHeader),
+                              sizeof(kWindowHeader));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
 TEST_F(VCDiffInterleavedCrossDecoderTest, Decode) {
@@ -797,16 +803,16 @@ TEST_F(VCDiffInterleavedCrossDecoderTestByteByByte, DecodeWithChecksum) {
 // format.
 class VCDiffCustomCodeTableDecoderTest : public VCDiffInterleavedDecoderTest {
  protected:
-  static const char kFileHeader[];
-  static const char kWindowHeader[];
-  static const char kWindowBody[];
-  static const char kEncodedCustomCodeTable[];
+  static const uint8_t kFileHeader[];
+  static const uint8_t kWindowHeader[];
+  static const uint8_t kWindowBody[];
+  static const uint8_t kEncodedCustomCodeTable[];
 
   VCDiffCustomCodeTableDecoderTest();
   virtual ~VCDiffCustomCodeTableDecoderTest() {}
 };
 
-const char VCDiffCustomCodeTableDecoderTest::kFileHeader[] = {
+const uint8_t VCDiffCustomCodeTableDecoderTest::kFileHeader[] = {
     0xD6,  // 'V' | 0x80
     0xC3,  // 'C' | 0x80
     0xC4,  // 'D' | 0x80
@@ -828,7 +834,7 @@ const char VCDiffCustomCodeTableDecoderTest::kFileHeader[] = {
 // COPY mode 0 size 18 (opcode 34) => COPY mode 0 size 28 (size1[34] = 28)
 // COPY mode 1 size 18 (opcode 50) => COPY mode 1 size 44 (size1[50] = 44)
 //
-const char VCDiffCustomCodeTableDecoderTest::kEncodedCustomCodeTable[] = {
+const uint8_t VCDiffCustomCodeTableDecoderTest::kEncodedCustomCodeTable[] = {
     0xD6,  // 'V' | 0x80
     0xC3,  // 'C' | 0x80
     0xC4,  // 'D' | 0x80
@@ -879,7 +885,7 @@ const char VCDiffCustomCodeTableDecoderTest::kEncodedCustomCodeTable[] = {
 // has the size of the NEAR cache set to 1; only the most recent
 // COPY instruction is available.  This will also be a test of
 // custom cache sizes.
-const char VCDiffCustomCodeTableDecoderTest::kWindowHeader[] = {
+const uint8_t VCDiffCustomCodeTableDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
@@ -893,7 +899,7 @@ const char VCDiffCustomCodeTableDecoderTest::kWindowHeader[] = {
     0x00   // length of addresses for COPYs (unused)
   };
 
-const char VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
     0x22,  // VCD_COPY mode VCD_SELF, size 28
     0x00,  // Address of COPY: Start of dictionary
     0x12,  // VCD_ADD size 61
@@ -925,13 +931,16 @@ const char VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
   };
 
 VCDiffCustomCodeTableDecoderTest::VCDiffCustomCodeTableDecoderTest() {
-  delta_file_header_.assign(kFileHeader, sizeof(kFileHeader));
+  delta_file_header_.assign(reinterpret_cast<const char *>(kFileHeader),
+                            sizeof(kFileHeader));
   delta_file_header_.push_back(0x01);  // NEAR cache size (custom)
   delta_file_header_.push_back(0x06);  // SAME cache size (custom)
-  delta_file_header_.append(kEncodedCustomCodeTable,
+  delta_file_header_.append(reinterpret_cast<const char*>(kEncodedCustomCodeTable),
                             sizeof(kEncodedCustomCodeTable));
-  delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_header_.assign(reinterpret_cast<const char *>(kWindowHeader),
+                              sizeof(kWindowHeader));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
 TEST_F(VCDiffCustomCodeTableDecoderTest, CustomCodeTableEncodingMatches) {
@@ -947,9 +956,9 @@ TEST_F(VCDiffCustomCodeTableDecoderTest, CustomCodeTableEncodingMatches) {
       reinterpret_cast<const char*>(
           &VCDiffCodeTableData::kDefaultCodeTableData),
       sizeof(VCDiffCodeTableData::kDefaultCodeTableData));
-  EXPECT_TRUE(decoder_.DecodeChunk(kEncodedCustomCodeTable,
-                                   sizeof(kEncodedCustomCodeTable),
-                                   &output_));
+  EXPECT_TRUE(decoder_.DecodeChunk(
+      reinterpret_cast<const char *>(kEncodedCustomCodeTable),
+      sizeof(kEncodedCustomCodeTable), &output_));
   EXPECT_TRUE(decoder_.FinishDecoding());
   EXPECT_EQ(sizeof(custom_code_table), output_.size());
   const VCDiffCodeTableData* decoded_table =
@@ -1031,11 +1040,13 @@ void VCDiffCustomCacheSizeTest::CustomCacheSizeTest(int32_t near_value,
                                                     int32_t same_value) {
   SCOPED_TRACE(testing::Message() << "Near value: " << near_value
                                   << ", same value: " << same_value);
-  delta_file_header_.assign(kFileHeader, sizeof(kFileHeader));
+  delta_file_header_.assign(reinterpret_cast<const char *>(kFileHeader),
+                            sizeof(kFileHeader));
   VarintBE<int32_t>::AppendToString(near_value, &delta_file_header_);
   VarintBE<int32_t>::AppendToString(same_value, &delta_file_header_);
-  delta_file_header_.append(kEncodedCustomCodeTable,
-                            sizeof(kEncodedCustomCodeTable));
+  delta_file_header_.append(
+      reinterpret_cast<const char *>(kEncodedCustomCodeTable),
+      sizeof(kEncodedCustomCodeTable));
   InitializeDeltaFile();
   EXPECT_DEBUG_DEATH({
     decoder_.StartDecoding(dictionary_.data(), dictionary_.size());

--- a/src/vcdecoder5_test.cc
+++ b/src/vcdecoder5_test.cc
@@ -29,10 +29,10 @@ class VCDiffLargeTargetTest : public VCDiffDecoderTest {
   VCDiffLargeTargetTest();
   virtual ~VCDiffLargeTargetTest() {}
 
-  static const char kLargeRunWindow[];
+  static const uint8_t kLargeRunWindow[];
 };
 
-const char VCDiffLargeTargetTest::kLargeRunWindow[] = {
+const uint8_t VCDiffLargeTargetTest::kLargeRunWindow[] = {
     0x00,  // Win_Indicator: no source segment
     0x0E,  // Length of the delta encoding
     0xA0,  // Size of the target window (0x4000000)
@@ -70,8 +70,9 @@ TEST_F(VCDiffLargeTargetTest, Decode) {
                                    &output_));
   EXPECT_EQ("", output_);
   for (int i = 0; i < kIterations; i++) {
-    EXPECT_TRUE(decoder_.DecodeChunk(kLargeRunWindow, sizeof(kLargeRunWindow),
-                                     &output_));
+    EXPECT_TRUE(
+        decoder_.DecodeChunk(reinterpret_cast<const char *>(kLargeRunWindow),
+                             sizeof(kLargeRunWindow), &output_));
     EXPECT_EQ(0x4000000U, output_.size());
     EXPECT_EQ(static_cast<char>(0xBE), output_[0]);
     EXPECT_EQ(static_cast<char>(0xBE),
@@ -94,8 +95,9 @@ TEST_F(VCDiffLargeTargetTest, DecodeReachesMaxFileSize) {
   EXPECT_EQ("", output_);
   // The default maximum target file size is 64MB, which just matches the target
   // data produced by a single iteration.
-  EXPECT_TRUE(decoder_.DecodeChunk(kLargeRunWindow, sizeof(kLargeRunWindow),
-                                   &output_));
+  EXPECT_TRUE(
+      decoder_.DecodeChunk(reinterpret_cast<const char *>(kLargeRunWindow),
+                           sizeof(kLargeRunWindow), &output_));
   EXPECT_EQ(0x4000000U, output_.size());
   EXPECT_EQ(static_cast<char>(0xBE), output_[0]);
   EXPECT_EQ(static_cast<char>(0xBE),
@@ -104,8 +106,9 @@ TEST_F(VCDiffLargeTargetTest, DecodeReachesMaxFileSize) {
             output_[output_.size() - 1]);  // last element
   output_.clear();
   // Trying to decode a second window should exceed the target file size limit.
-  EXPECT_FALSE(decoder_.DecodeChunk(kLargeRunWindow, sizeof(kLargeRunWindow),
-                                    &output_));
+  EXPECT_FALSE(
+      decoder_.DecodeChunk(reinterpret_cast<const char *>(kLargeRunWindow),
+                           sizeof(kLargeRunWindow), &output_));
 }
 
 }  // unnamed namespace

--- a/src/vcdecoder_test.cc
+++ b/src/vcdecoder_test.cc
@@ -14,7 +14,6 @@
 
 #include <config.h>
 #include "vcdecoder_test.h"
-#include <stdint.h>  // utf8_t
 #include <string.h>  // strlen
 #include "checksum.h"
 #include "codetable.h"
@@ -24,7 +23,7 @@
 
 namespace open_vcdiff {
 
-const char VCDiffDecoderTest::kStandardFileHeader[] = {
+const uint8_t VCDiffDecoderTest::kStandardFileHeader[] = {
     0xD6,  // 'V' | 0x80
     0xC3,  // 'C' | 0x80
     0xC4,  // 'D' | 0x80
@@ -32,7 +31,7 @@ const char VCDiffDecoderTest::kStandardFileHeader[] = {
     0x00   // Hdr_Indicator: no custom code table, no compression
   };
 
-const char VCDiffDecoderTest::kInterleavedFileHeader[] = {
+const uint8_t VCDiffDecoderTest::kInterleavedFileHeader[] = {
     0xD6,  // 'V' | 0x80
     0xC3,  // 'C' | 0x80
     0xC4,  // 'D' | 0x80
@@ -62,21 +61,22 @@ void VCDiffDecoderTest::SetUp() {
 }
 
 void VCDiffDecoderTest::UseStandardFileHeader() {
-  delta_file_header_.assign(kStandardFileHeader,
+  delta_file_header_.assign(reinterpret_cast<const char *>(kStandardFileHeader),
                             sizeof(kStandardFileHeader));
 }
 
 void VCDiffDecoderTest::UseInterleavedFileHeader() {
-  delta_file_header_.assign(kInterleavedFileHeader,
-                            sizeof(kInterleavedFileHeader));
+  delta_file_header_.assign(
+      reinterpret_cast<const char *>(kInterleavedFileHeader),
+      sizeof(kInterleavedFileHeader));
 }
 
 void VCDiffDecoderTest::InitializeDeltaFile() {
   delta_file_ = delta_file_header_ + delta_window_header_ + delta_window_body_;
 }
 
-char VCDiffDecoderTest::GetByteFromStringLength(const char* s,
-                                                int which_byte) {
+uint8_t VCDiffDecoderTest::GetByteFromStringLength(const char* s,
+                                                   int which_byte) {
   char varint_buf[VarintBE<int32_t>::kMaxBytes];
   VarintBE<int32_t>::Encode(static_cast<int32_t>(strlen(s)), varint_buf);
   return varint_buf[which_byte];
@@ -163,7 +163,7 @@ bool VCDiffDecoderTest::FuzzOneByteInDeltaFile() {
   return false;
 }
 
-const char VCDiffStandardDecoderTest::kWindowHeader[] = {
+const uint8_t VCDiffStandardDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
@@ -177,7 +177,7 @@ const char VCDiffStandardDecoderTest::kWindowHeader[] = {
     0x03  // length of addresses for COPYs
   };
 
-const char VCDiffStandardDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffStandardDecoderTest::kWindowBody[] = {
     // Data for ADDs: 1st section (length 61)
     ' ', 'I', ' ', 'h', 'a', 'v', 'e', ' ', 's', 'a', 'i', 'd', ' ',
     'i', 't', ' ', 't', 'w', 'i', 'c', 'e', ':', '\n',
@@ -217,11 +217,13 @@ const char VCDiffStandardDecoderTest::kWindowBody[] = {
 
 VCDiffStandardDecoderTest::VCDiffStandardDecoderTest() {
   UseStandardFileHeader();
-  delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_header_.assign(reinterpret_cast<const char *>(kWindowHeader),
+                              sizeof(kWindowHeader));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
-const char VCDiffInterleavedDecoderTest::kWindowHeader[] = {
+const uint8_t VCDiffInterleavedDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
@@ -235,7 +237,7 @@ const char VCDiffInterleavedDecoderTest::kWindowHeader[] = {
     0x00  // length of addresses for COPYs (unused)
   };
 
-const char VCDiffInterleavedDecoderTest::kWindowBody[] = {
+const uint8_t VCDiffInterleavedDecoderTest::kWindowBody[] = {
     0x13,  // VCD_COPY mode VCD_SELF, size 0
     0x1C,  // Size of COPY (28)
     0x00,  // Address of COPY: Start of dictionary
@@ -273,8 +275,10 @@ const char VCDiffInterleavedDecoderTest::kWindowBody[] = {
 
 VCDiffInterleavedDecoderTest::VCDiffInterleavedDecoderTest() {
   UseInterleavedFileHeader();
-  delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));
-  delta_window_body_.assign(kWindowBody, sizeof(kWindowBody));
+  delta_window_header_.assign(reinterpret_cast<const char *>(kWindowHeader),
+                              sizeof(kWindowHeader));
+  delta_window_body_.assign(reinterpret_cast<const char *>(kWindowBody),
+                            sizeof(kWindowBody));
 }
 
 }  // namespace open_vcdiff

--- a/src/vcdecoder_test.cc
+++ b/src/vcdecoder_test.cc
@@ -14,6 +14,7 @@
 
 #include <config.h>
 #include "vcdecoder_test.h"
+#include <stdint.h>  // utf8_t
 #include <string.h>  // strlen
 #include "checksum.h"
 #include "codetable.h"
@@ -101,10 +102,10 @@ void VCDiffDecoderTest::ComputeAndAddChecksum() {
 // (0x7FFFFFFF) at the given offset in the delta window.
 void VCDiffDecoderTest::WriteMaxVarintAtOffset(int offset,
                                                int bytes_to_replace) {
-  static const char kMaxVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0x7F };
+  static const uint8_t kMaxVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0x7F };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
-                      kMaxVarint,
+                      reinterpret_cast<const char*>(kMaxVarint),
                       sizeof(kMaxVarint));
 }
 
@@ -112,10 +113,10 @@ void VCDiffDecoderTest::WriteMaxVarintAtOffset(int offset,
 // in the delta window.
 void VCDiffDecoderTest::WriteNegativeVarintAtOffset(int offset,
                                                     int bytes_to_replace) {
-  static const char kNegativeVarint[] = { 0x88, 0x80, 0x80, 0x80, 0x00 };
+  static const uint8_t kNegativeVarint[] = { 0x88, 0x80, 0x80, 0x80, 0x00 };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
-                      kNegativeVarint,
+                      reinterpret_cast<const char*>(kNegativeVarint),
                       sizeof(kNegativeVarint));
 }
 
@@ -123,18 +124,18 @@ void VCDiffDecoderTest::WriteNegativeVarintAtOffset(int offset,
 // at the given offset in the delta window.
 void VCDiffDecoderTest::WriteInvalidVarintAtOffset(int offset,
                                                    int bytes_to_replace) {
-  static const char kInvalidVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F };
+  static const uint8_t kInvalidVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
-                      kInvalidVarint,
+                      reinterpret_cast<const char*>(kInvalidVarint),
                       sizeof(kInvalidVarint));
 }
 
 bool VCDiffDecoderTest::FuzzOneByteInDeltaFile() {
   static const struct Fuzzer {
-    char _and;
-    char _or;
-    char _xor;
+    uint8_t _and;
+    uint8_t _or;
+    uint8_t _xor;
   } fuzzers[] = {
     { 0xff, 0x80, 0x00 },
     { 0xff, 0xff, 0x00 },

--- a/src/vcdecoder_test.h
+++ b/src/vcdecoder_test.h
@@ -16,6 +16,7 @@
 #define OPEN_VCDIFF_VCDECODER_TEST_H_
 
 #include "google/vcdecoder.h"
+#include <stdint.h>  // utf8_t
 #include <string>
 #include "checksum.h"
 #include "testing.h"
@@ -80,7 +81,7 @@ class VCDiffDecoderTest : public testing::Test {
   // Assuming the length of the given string can be expressed as a VarintBE
   // of length N, this function returns the byte at position which_byte, where
   // 0 <= which_byte < N.
-  static char GetByteFromStringLength(const char* s, int which_byte);
+  static uint8_t GetByteFromStringLength(const char* s, int which_byte);
 
   // Assuming the length of the given string can be expressed as a one-byte
   // VarintBE, this function returns that byte value.
@@ -90,13 +91,13 @@ class VCDiffDecoderTest : public testing::Test {
 
   // Assuming the length of the given string can be expressed as a two-byte
   // VarintBE, this function returns the first byte of its representation.
-  static char FirstByteOfStringLength(const char* s) {
+  static uint8_t FirstByteOfStringLength(const char* s) {
     return GetByteFromStringLength(s, 0);
   }
 
   // Assuming the length of the given string can be expressed as a two-byte
   // VarintBE, this function returns the second byte of its representation.
-  static char SecondByteOfStringLength(const char* s) {
+  static uint8_t SecondByteOfStringLength(const char* s) {
     return GetByteFromStringLength(s, 1);
   }
 
@@ -124,8 +125,8 @@ class VCDiffDecoderTest : public testing::Test {
  private:
   // These values should only be accessed via UseStandardFileHeader() and
   // UseInterleavedFileHeader().
-  static const char kStandardFileHeader[];
-  static const char kInterleavedFileHeader[];
+  static const uint8_t kStandardFileHeader[];
+  static const uint8_t kInterleavedFileHeader[];
 
   // These two counters are used by FuzzOneByteInDeltaFile() to iterate through
   // different ways to corrupt the delta file.
@@ -141,8 +142,8 @@ class VCDiffStandardDecoderTest : public VCDiffDecoderTest {
   virtual ~VCDiffStandardDecoderTest() {}
 
  private:
-  static const char kWindowHeader[];
-  static const char kWindowBody[];
+  static const uint8_t kWindowHeader[];
+  static const uint8_t kWindowBody[];
 };
 
 class VCDiffInterleavedDecoderTest : public VCDiffDecoderTest {
@@ -151,8 +152,8 @@ class VCDiffInterleavedDecoderTest : public VCDiffDecoderTest {
   virtual ~VCDiffInterleavedDecoderTest() {}
 
  private:
-  static const char kWindowHeader[];
-  static const char kWindowBody[];
+  static const uint8_t kWindowHeader[];
+  static const uint8_t kWindowBody[];
 };
 
 }  // namespace open_vcdiff

--- a/src/vcdecoder_test.h
+++ b/src/vcdecoder_test.h
@@ -85,7 +85,7 @@ class VCDiffDecoderTest : public testing::Test {
 
   // Assuming the length of the given string can be expressed as a one-byte
   // VarintBE, this function returns that byte value.
-  static char StringLengthAsByte(const char* s) {
+  static uint8_t StringLengthAsByte(const char* s) {
     return GetByteFromStringLength(s, 0);
   }
 


### PR DESCRIPTION
Fixes #67 

Basically I switched storing of test data to uint8_t. It's not perfect solution because requires quite few of reinterpret_cast to const char_. But it will simplify future testing for implementation of #4. However I'm slightly disagree about using `void *` and in favour of ```uint8_t_```
