### PR TITLE
Resolve C++11 narrowing conversion errors

### DIFF
--- a/src/varint_bigendian_test.cc
+++ b/src/varint_bigendian_test.cc
@@ -106,10 +106,10 @@ typedef VarintBEInt64Test VarintBEInt64DeathTest;
 #endif  // GTEST_HAS_DEATH_TEST
 
 const char VarintBETestCommon::parse_data_all_FFs[] =
-    { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF' };
 
 const char VarintBETestCommon::parse_data_CADA1[] =
-    { 0xCA, 0xDA, 0x01 };
+    { '\xCA', '\xDA', '\x01' };
 
 // A macro to allow defining tests once and having them run against
 // both VarintBE<int32_t> and VarintBE<int64_t>.
@@ -135,33 +135,33 @@ TEMPLATE_TEST_F(DeathTest, DISABLED_EncodeNegative) {
 
 TEMPLATE_TEST_F(Test, EncodeZero) {
   StartEncodingTest(/* value */ 0x00, /* expected length */ 1);
-  ExpectEncodedByte(0x00);
+  ExpectEncodedByte('\x00');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
 TEMPLATE_TEST_F(Test, EncodeEightBits) {
   StartEncodingTest(/* value */ 0xFF, /* expected length */ 2);
-  ExpectEncodedByte(0x81);
-  ExpectEncodedByte(0x7F);
+  ExpectEncodedByte('\x81');
+  ExpectEncodedByte('\x7F');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
 TEMPLATE_TEST_F(Test, EncodeCADAD1A) {
   StartEncodingTest(/* value */ 0x0CADAD1A, /* expected length */ 4);
-  ExpectEncodedByte(0xE5);
-  ExpectEncodedByte(0xB6);
-  ExpectEncodedByte(0xDA);
-  ExpectEncodedByte(0x1A);
+  ExpectEncodedByte('\xE5');
+  ExpectEncodedByte('\xB6');
+  ExpectEncodedByte('\xDA');
+  ExpectEncodedByte('\x1A');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
 TEMPLATE_TEST_F(Test, Encode32BitMaxInt) {
   StartEncodingTest(/* value */ 0x7FFFFFFF, /* expected length */ 5);
-  ExpectEncodedByte(0x87);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0x7F);
+  ExpectEncodedByte('\x87');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\x7F');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
@@ -174,25 +174,25 @@ TEST_F(VarintBEInt32DeathTest, DISABLED_Encode32BitsTooBig) {
 
 TEST_F(VarintBEInt64Test, Encode32Bits) {
   StartEncodingTest(/* value */ 0x80000000, /* expected length */ 5);
-  ExpectEncodedByte(0x88);
-  ExpectEncodedByte(0x80);
-  ExpectEncodedByte(0x80);
-  ExpectEncodedByte(0x80);
-  ExpectEncodedByte(0x00);
+  ExpectEncodedByte('\x88');
+  ExpectEncodedByte('\x80');
+  ExpectEncodedByte('\x80');
+  ExpectEncodedByte('\x80');
+  ExpectEncodedByte('\x00');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
 TEST_F(VarintBEInt64Test, Encode63Bits) {
   StartEncodingTest(/* value */ 0x7FFFFFFFFFFFFFFFULL, /* expected length */ 9);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0xFF);
-  ExpectEncodedByte(0x7F);
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\xFF');
+  ExpectEncodedByte('\x7F');
   EXPECT_EQ(verify_expected_length_, verify_encoded_byte_index_);
 }
 
@@ -241,7 +241,7 @@ TEST_F(VarintBEInt64Test, ParseEightFFs) {
 }
 
 TEMPLATE_TEST_F(Test, ParseZero) {
-  const char zero_data[] = { 0x00 };
+  const char zero_data[] = { '\x00' };
   parse_data_ptr_ = zero_data;
   EXPECT_EQ(0x00, VarintType::Parse(parse_data_ptr_ + 1, &parse_data_ptr_));
   EXPECT_EQ(zero_data + 1, parse_data_ptr_);
@@ -275,7 +275,7 @@ TEMPLATE_TEST_F(Test, ParseEmpty) {
 
 // This example is taken from the Varint description in RFC 3284, section 2.
 TEMPLATE_TEST_F(Test, Parse123456789) {
-  const char parse_data_123456789[] = { 0x80 + 58, 0x80 + 111, 0x80 + 26, 21 };
+  const char parse_data_123456789[] = { '\x80' + 58, '\x80' + 111, '\x80' + 26, 21 };
   parse_data_ptr_ = parse_data_123456789;
   EXPECT_EQ(123456789, VarintType::Parse(parse_data_123456789
                                              + sizeof(parse_data_123456789),
@@ -283,7 +283,7 @@ TEMPLATE_TEST_F(Test, Parse123456789) {
 }
 
 TEMPLATE_TEST_F(Test, Decode31Bits) {
-  const char parse_data_31_bits[] = { 0x87, 0xFF, 0xFF, 0xFF, 0x7F };
+  const char parse_data_31_bits[] = { '\x87', '\xFF', '\xFF', '\xFF', '\x7F' };
   parse_data_ptr_ = parse_data_31_bits;
   EXPECT_EQ(0x7FFFFFFF,
             VarintType::Parse(parse_data_31_bits + sizeof(parse_data_31_bits),
@@ -291,7 +291,7 @@ TEMPLATE_TEST_F(Test, Decode31Bits) {
 }
 
 TEST_F(VarintBEInt32Test, Decode32Bits) {
-  const char parse_data_32_bits[] = { 0x88, 0x80, 0x80, 0x80, 0x00 };
+  const char parse_data_32_bits[] = { '\x88', '\x80', '\x80', '\x80', '\x00' };
   parse_data_ptr_ = parse_data_32_bits;
   EXPECT_EQ(RESULT_ERROR,
             VarintType::Parse(parse_data_32_bits + sizeof(parse_data_32_bits),
@@ -299,7 +299,7 @@ TEST_F(VarintBEInt32Test, Decode32Bits) {
 }
 
 TEST_F(VarintBEInt64Test, Decode32Bits) {
-  const char parse_data_32_bits[] = { 0x88, 0x80, 0x80, 0x80, 0x00 };
+  const char parse_data_32_bits[] = { '\x88', '\x80', '\x80', '\x80', '\x00' };
   parse_data_ptr_ = parse_data_32_bits;
   EXPECT_EQ(0x80000000,
             VarintType::Parse(parse_data_32_bits + sizeof(parse_data_32_bits),
@@ -338,9 +338,9 @@ TEMPLATE_TEST_F(Test, EncodeDecodeRandom) {
 // bytes, but they should not cause us to read past the end of available input.
 TEMPLATE_TEST_F(Test, ContinuationBytesPastEndOfInput) {
   const char parse_data_20_continuations[] =
-    { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
-      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
-      0x00 };
+    { '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80',
+      '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80', '\x80',
+      '\x00' };
   parse_data_ptr_ = parse_data_20_continuations;
   EXPECT_EQ(RESULT_END_OF_DATA,
             VarintType::Parse(parse_data_20_continuations + 10,

--- a/src/vcdecoder3_test.cc
+++ b/src/vcdecoder3_test.cc
@@ -118,8 +118,8 @@ TEST_F(VCDiffInterleavedDecoderTest, ChecksumDoesNotMatch) {
 }
 
 TEST_F(VCDiffInterleavedDecoderTest, ChecksumIsInvalid64BitVarint) {
-  static const char kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
-                                         0x80, 0x80, 0x80, 0x00 };
+  static const char kInvalidVarint[] = { '\x81', '\x80', '\x80', '\x80', '\x80', '\x80',
+                                         '\x80', '\x80', '\x80', '\x00' };
   delta_window_header_[0] |= VCD_CHECKSUM;
   delta_window_header_.append(kInvalidVarint, sizeof(kInvalidVarint));
   // Adjust delta window size to include size of invalid Varint.
@@ -659,8 +659,8 @@ TEST_F(VCDiffInterleavedDecoderTestByteByByte, ChecksumDoesNotMatch) {
 }
 
 TEST_F(VCDiffInterleavedDecoderTestByteByByte, ChecksumIsInvalid64BitVarint) {
-  static const char kInvalidVarint[] = { 0x81, 0x80, 0x80, 0x80, 0x80, 0x80,
-                                         0x80, 0x80, 0x80, 0x00 };
+  static const char kInvalidVarint[] = { '\x81', '\x80', '\x80', '\x80', '\x80', '\x80',
+                                         '\x80', '\x80', '\x80', '\x00' };
   delta_window_header_[0] |= VCD_CHECKSUM;
   delta_window_header_.append(kInvalidVarint, sizeof(kInvalidVarint));
   // Adjust delta window size to include size of invalid Varint.

--- a/src/vcdecoder4_test.cc
+++ b/src/vcdecoder4_test.cc
@@ -835,11 +835,11 @@ const char VCDiffCustomCodeTableDecoderTest::kEncodedCustomCodeTable[] = {
     'S',   // SDCH version code
     '\x00',  // Hdr_Indicator: no custom code table, no compression
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
-    (sizeof(VCDiffCodeTableData) >> 7) | 0x80,  // First byte of table length
+    static_cast<const char>((sizeof(VCDiffCodeTableData) >> 7) | 0x80),  // First byte of table length
     sizeof(VCDiffCodeTableData) & 0x7F,  // Second byte of table length
     '\x00',  // Source segment position: start of default code table
     '\x1F',  // Length of the delta encoding
-    (sizeof(VCDiffCodeTableData) >> 7) | 0x80,  // First byte of table length
+    static_cast<const char>((sizeof(VCDiffCodeTableData) >> 7) | 0x80),  // First byte of table length
     sizeof(VCDiffCodeTableData) & 0x7F,  // Second byte of table length
     '\x00',  // Delta_indicator (no compression)
     '\x00',  // length of data for ADDs and RUNs (unused)

--- a/src/vcdecoder4_test.cc
+++ b/src/vcdecoder4_test.cc
@@ -131,27 +131,27 @@ const char VCDiffStandardWindowDecoderTest::kWindowBody[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x08,  // Length of the delta encoding
-    0x1C,  // Size of the target window (28)
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x02,  // length of instructions section
-    0x01,  // length of addresses for COPYs
+    '\x00',  // Source segment position: start of dictionary
+    '\x08',  // Length of the delta encoding
+    '\x1C',  // Size of the target window (28)
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x02',  // length of instructions section
+    '\x01',  // length of addresses for COPYs
     // No data for ADDs and RUNs
     // Instructions and sizes (length 2)
-    0x13,  // VCD_COPY mode VCD_SELF, size 0
-    0x1C,  // Size of COPY (28)
+    '\x13',  // VCD_COPY mode VCD_SELF, size 0
+    '\x1C',  // Size of COPY (28)
     // Addresses for COPYs (length 1)
-    0x00,  // Start of dictionary
+    '\x00',  // Start of dictionary
 // Window 2:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x44,  // Length of the delta encoding
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x44',  // Length of the delta encoding
     static_cast<char>(kWindow2Size),  // Size of the target window (61)
-    0x00,  // Delta_indicator (no compression)
-    0x3D,  // length of data for ADDs and RUNs
-    0x02,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Delta_indicator (no compression)
+    '\x3D',  // length of data for ADDs and RUNs
+    '\x02',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
     // Data for ADD (length 61)
     ' ', 'I', ' ', 'h', 'a', 'v', 'e', ' ', 's', 'a', 'i', 'd', ' ',
     'i', 't', ' ', 't', 'w', 'i', 'c', 'e', ':', '\n',
@@ -160,83 +160,83 @@ const char VCDiffStandardWindowDecoderTest::kWindowBody[] = {
     'e', 'n', 'c', 'o', 'u', 'r', 'a', 'g', 'e', ' ',
     't', 'h', 'e', ' ', 'c', 'r', 'e', 'w', '.', '\n',
     // Instructions and sizes (length 2)
-    0x01,  // VCD_ADD size 0
-    0x3D,  // Size of ADD (61)
+    '\x01',  // VCD_ADD size 0
+    '\x3D',  // Size of ADD (61)
     // No addresses for COPYs
 // Window 3:
     VCD_TARGET,  // Win_Indicator: take source from decoded data
-    0x59,  // Source segment size: length of data decoded so far
-    0x00,  // Source segment position: start of decoded data
-    0x08,  // Length of the delta encoding
-    0x2C,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x02,  // length of instructions section
-    0x01,  // length of addresses for COPYs
+    '\x59',  // Source segment size: length of data decoded so far
+    '\x00',  // Source segment position: start of decoded data
+    '\x08',  // Length of the delta encoding
+    '\x2C',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x02',  // length of instructions section
+    '\x01',  // length of addresses for COPYs
     // No data for ADDs and RUNs
     // Instructions and sizes (length 2)
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x2C,  // Size of COPY (44)
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x2C',  // Size of COPY (44)
     // Addresses for COPYs (length 1)
-    0x58,  // HERE mode address (27+61 back from here_address)
+    '\x58',  // HERE mode address (27+61 back from here_address)
 // Window 4:
     VCD_TARGET,  // Win_Indicator: take source from decoded data
-    0x05,  // Source segment size: only 5 bytes needed for this COPY
-    0x2E,  // Source segment position: offset for COPY
-    0x09,  // Length of the delta encoding
-    0x07,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x02,  // length of data for ADDs and RUNs
-    0x01,  // length of instructions section
-    0x01,  // length of addresses for COPYs
+    '\x05',  // Source segment size: only 5 bytes needed for this COPY
+    '\x2E',  // Source segment position: offset for COPY
+    '\x09',  // Length of the delta encoding
+    '\x07',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x02',  // length of data for ADDs and RUNs
+    '\x01',  // length of instructions section
+    '\x01',  // length of addresses for COPYs
     // Data for ADD (length 2)
     'h', 'r',
     // Instructions and sizes (length 1)
-    0xA7,  // VCD_ADD size 2 + VCD_COPY mode SELF size 5
+    '\xA7',  // VCD_ADD size 2 + VCD_COPY mode SELF size 5
     // Addresses for COPYs (length 1)
-    0x00,  // SELF mode address (start of source segment)
+    '\x00',  // SELF mode address (start of source segment)
 // Window 5:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x0F,  // Length of the delta encoding
-    0x09,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x09,  // length of data for ADDs and RUNs
-    0x01,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x0F',  // Length of the delta encoding
+    '\x09',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x09',  // length of data for ADDs and RUNs
+    '\x01',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
     // Data for ADD (length 9)
     'W', 'h', 'a', 't', ' ', 'I', ' ', 't', 'e',
     // Instructions and sizes (length 1)
-    0x0A,       // VCD_ADD size 9
+    '\x0A',       // VCD_ADD size 9
     // No addresses for COPYs
 // Window 6:
-    0x00,  // Win_Indicator: No source segment (RUN only)
-    0x08,  // Length of the delta encoding
-    0x02,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x01,  // length of data for ADDs and RUNs
-    0x02,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Win_Indicator: No source segment (RUN only)
+    '\x08',  // Length of the delta encoding
+    '\x02',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x01',  // length of data for ADDs and RUNs
+    '\x02',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
     // Data for RUN (length 1)
     'l',
     // Instructions and sizes (length 2)
-    0x00,  // VCD_RUN size 0
-    0x02,  // Size of RUN (2)
+    '\x00',  // VCD_RUN size 0
+    '\x02',  // Size of RUN (2)
     // No addresses for COPYs
 // Window 7:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x22,  // Length of the delta encoding
-    0x1B,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x1B,  // length of data for ADDs and RUNs
-    0x02,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x22',  // Length of the delta encoding
+    '\x1B',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x1B',  // length of data for ADDs and RUNs
+    '\x02',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
     // Data for ADD: 4th section (length 27)
     ' ', 'y', 'o', 'u', ' ',
     't', 'h', 'r', 'e', 'e', ' ', 't', 'i', 'm', 'e', 's', ' ', 'i', 's', ' ',
     't', 'r', 'u', 'e', '.', '\"', '\n',
     // Instructions and sizes (length 2)
-    0x01,  // VCD_ADD size 0
-    0x1B,  // Size of ADD (27)
+    '\x01',  // VCD_ADD size 0
+    '\x1B',  // Size of ADD (27)
     // No addresses for COPYs
   };
 
@@ -430,26 +430,26 @@ const char VCDiffInterleavedWindowDecoderTest::kWindowBody[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x08,  // Length of the delta encoding
-    0x1C,  // Size of the target window (28)
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x03,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x13,  // VCD_COPY mode VCD_SELF, size 0
-    0x1C,  // Size of COPY (28)
-    0x00,  // Start of dictionary
+    '\x00',  // Source segment position: start of dictionary
+    '\x08',  // Length of the delta encoding
+    '\x1C',  // Size of the target window (28)
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x03',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x13',  // VCD_COPY mode VCD_SELF, size 0
+    '\x1C',  // Size of COPY (28)
+    '\x00',  // Start of dictionary
 // Window 2:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x44,  // Length of the delta encoding
-    0x3D,  // Size of the target window (61)
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x3F,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x01,  // VCD_ADD size 0
-    0x3D,  // Size of ADD (61)
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x44',  // Length of the delta encoding
+    '\x3D',  // Size of the target window (61)
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x3F',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x01',  // VCD_ADD size 0
+    '\x3D',  // Size of ADD (61)
     ' ', 'I', ' ', 'h', 'a', 'v', 'e', ' ', 's', 'a', 'i', 'd', ' ',
     'i', 't', ' ', 't', 'w', 'i', 'c', 'e', ':', '\n',
     'T', 'h', 'a', 't', ' ',
@@ -458,61 +458,61 @@ const char VCDiffInterleavedWindowDecoderTest::kWindowBody[] = {
     't', 'h', 'e', ' ', 'c', 'r', 'e', 'w', '.', '\n',
 // Window 3:
     VCD_TARGET,  // Win_Indicator: take source from decoded data
-    0x59,  // Source segment size: length of data decoded so far
-    0x00,  // Source segment position: start of decoded data
-    0x08,  // Length of the delta encoding
-    0x2C,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x03,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x2C,  // Size of COPY (44)
-    0x58,  // HERE mode address (27+61 back from here_address)
+    '\x59',  // Source segment size: length of data decoded so far
+    '\x00',  // Source segment position: start of decoded data
+    '\x08',  // Length of the delta encoding
+    '\x2C',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x03',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x2C',  // Size of COPY (44)
+    '\x58',  // HERE mode address (27+61 back from here_address)
 // Window 4:
     VCD_TARGET,  // Win_Indicator: take source from decoded data
-    0x05,  // Source segment size: only 5 bytes needed for this COPY
-    0x2E,  // Source segment position: offset for COPY
-    0x09,  // Length of the delta encoding
-    0x07,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x04,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0xA7,  // VCD_ADD size 2 + VCD_COPY mode SELF, size 5
+    '\x05',  // Source segment size: only 5 bytes needed for this COPY
+    '\x2E',  // Source segment position: offset for COPY
+    '\x09',  // Length of the delta encoding
+    '\x07',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x04',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\xA7',  // VCD_ADD size 2 + VCD_COPY mode SELF, size 5
     'h', 'r',
-    0x00,  // SELF mode address (start of source segment)
+    '\x00',  // SELF mode address (start of source segment)
 // Window 5:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x0F,  // Length of the delta encoding
-    0x09,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x0A,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x0A,       // VCD_ADD size 9
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x0F',  // Length of the delta encoding
+    '\x09',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x0A',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x0A',       // VCD_ADD size 9
     'W', 'h', 'a', 't', ' ', 'I', ' ', 't', 'e',
 // Window 6:
-    0x00,  // Win_Indicator: No source segment (RUN only)
-    0x08,  // Length of the delta encoding
-    0x02,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x03,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x00,  // VCD_RUN size 0
-    0x02,  // Size of RUN (2)
+    '\x00',  // Win_Indicator: No source segment (RUN only)
+    '\x08',  // Length of the delta encoding
+    '\x02',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x03',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x00',  // VCD_RUN size 0
+    '\x02',  // Size of RUN (2)
     'l',
 // Window 7:
-    0x00,  // Win_Indicator: No source segment (ADD only)
-    0x22,  // Length of the delta encoding
-    0x1B,  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x1D,  // length of instructions section
-    0x00,  // length of addresses for COPYs
-    0x01,  // VCD_ADD size 0
-    0x1B,  // Size of ADD (27)
+    '\x00',  // Win_Indicator: No source segment (ADD only)
+    '\x22',  // Length of the delta encoding
+    '\x1B',  // Size of the target window
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x1D',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
+    '\x01',  // VCD_ADD size 0
+    '\x1B',  // Size of ADD (27)
     ' ', 'y', 'o', 'u', ' ',
     't', 'h', 'r', 'e', 'e', ' ', 't', 'i', 'm', 'e', 's', ' ', 'i', 's', ' ',
     't', 'r', 'u', 'e', '.', '\"', '\n',
@@ -647,29 +647,29 @@ const char VCDiffStandardCrossDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x15,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of dictionary
+    '\x15',  // Length of the delta encoding
     StringLengthAsByte(kExpectedTarget),  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x07,  // length of data for ADDs and RUNs
-    0x06,  // length of instructions section
-    0x03   // length of addresses for COPYs
+    '\x00',  // Delta_indicator (no compression)
+    '\x07',  // length of data for ADDs and RUNs
+    '\x06',  // length of instructions section
+    '\x03'   // length of addresses for COPYs
   };
 
 const char VCDiffStandardCrossDecoderTest::kWindowBody[] = {
     // Data for ADD (length 7)
     'S', 'p', 'i', 'd', 'e', 'r', 's',
     // Instructions and sizes (length 6)
-    0x01,  // VCD_ADD size 0
-    0x07,  // Size of ADD (7)
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x19,  // Size of COPY (25)
-    0x14,  // VCD_COPY mode VCD_SELF, size 4
-    0x25,  // VCD_COPY mode VCD_HERE, size 5
+    '\x01',  // VCD_ADD size 0
+    '\x07',  // Size of ADD (7)
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x19',  // Size of COPY (25)
+    '\x14',  // VCD_COPY mode VCD_SELF, size 4
+    '\x25',  // VCD_COPY mode VCD_HERE, size 5
     // Addresses for COPYs (length 3)
-    0x15,  // HERE mode address for 1st copy (21 back from here_address)
-    0x06,  // SELF mode address for 2nd copy
-    0x14   // HERE mode address for 3rd copy
+    '\x15',  // HERE mode address for 1st copy (21 back from here_address)
+    '\x06',  // SELF mode address for 2nd copy
+    '\x14'   // HERE mode address for 3rd copy
   };
 
 const char VCDiffStandardCrossDecoderTest::kExpectedTarget[] =
@@ -721,27 +721,27 @@ const char VCDiffInterleavedCrossDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x15,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of dictionary
+    '\x15',  // Length of the delta encoding
     StringLengthAsByte(kExpectedTarget),  // Size of the target window
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x10,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x10',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
   };
 
 const char VCDiffInterleavedCrossDecoderTest::kWindowBody[] = {
-    0x01,  // VCD_ADD size 0
-    0x07,  // Size of ADD (7)
+    '\x01',  // VCD_ADD size 0
+    '\x07',  // Size of ADD (7)
     // Data for ADD (length 7)
     'S', 'p', 'i', 'd', 'e', 'r', 's',
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x19,  // Size of COPY (25)
-    0x15,  // HERE mode address for 1st copy (21 back from here_address)
-    0x14,  // VCD_COPY mode VCD_SELF, size 4
-    0x06,  // SELF mode address for 2nd copy
-    0x25,  // VCD_COPY mode VCD_HERE, size 5
-    0x14   // HERE mode address for 3rd copy
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x19',  // Size of COPY (25)
+    '\x15',  // HERE mode address for 1st copy (21 back from here_address)
+    '\x14',  // VCD_COPY mode VCD_SELF, size 4
+    '\x06',  // SELF mode address for 2nd copy
+    '\x25',  // VCD_COPY mode VCD_HERE, size 5
+    '\x14'   // HERE mode address for 3rd copy
   };
 
 VCDiffInterleavedCrossDecoderTest::VCDiffInterleavedCrossDecoderTest() {
@@ -807,11 +807,11 @@ class VCDiffCustomCodeTableDecoderTest : public VCDiffInterleavedDecoderTest {
 };
 
 const char VCDiffCustomCodeTableDecoderTest::kFileHeader[] = {
-    0xD6,  // 'V' | 0x80
-    0xC3,  // 'C' | 0x80
-    0xC4,  // 'D' | 0x80
+    '\xD6',  // 'V' | '\x80'
+    '\xC3',  // 'C' | '\x80'
+    '\xC4',  // 'D' | '\x80'
     'S',   // SDCH version code
-    0x02   // Hdr_Indicator: Use custom code table
+    '\x02'   // Hdr_Indicator: Use custom code table
   };
 
 // Make a custom code table that includes exactly the instructions we need
@@ -829,47 +829,47 @@ const char VCDiffCustomCodeTableDecoderTest::kFileHeader[] = {
 // COPY mode 1 size 18 (opcode 50) => COPY mode 1 size 44 (size1[50] = 44)
 //
 const char VCDiffCustomCodeTableDecoderTest::kEncodedCustomCodeTable[] = {
-    0xD6,  // 'V' | 0x80
-    0xC3,  // 'C' | 0x80
-    0xC4,  // 'D' | 0x80
+    '\xD6',  // 'V' | '\x80'
+    '\xC3',  // 'C' | '\x80'
+    '\xC4',  // 'D' | '\x80'
     'S',   // SDCH version code
-    0x00,  // Hdr_Indicator: no custom code table, no compression
+    '\x00',  // Hdr_Indicator: no custom code table, no compression
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     (sizeof(VCDiffCodeTableData) >> 7) | 0x80,  // First byte of table length
     sizeof(VCDiffCodeTableData) & 0x7F,  // Second byte of table length
-    0x00,  // Source segment position: start of default code table
-    0x1F,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of default code table
+    '\x1F',  // Length of the delta encoding
     (sizeof(VCDiffCodeTableData) >> 7) | 0x80,  // First byte of table length
     sizeof(VCDiffCodeTableData) & 0x7F,  // Second byte of table length
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs (unused)
-    0x19,  // length of interleaved section
-    0x00,  // length of addresses for COPYs (unused)
-    0x05,  // VCD_ADD size 4
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs (unused)
+    '\x19',  // length of interleaved section
+    '\x00',  // length of addresses for COPYs (unused)
+    '\x05',  // VCD_ADD size 4
     // Data for ADD (length 4)
     VCD_RUN, VCD_ADD, VCD_ADD, VCD_RUN,
-    0x13,  // VCD_COPY mode VCD_SELF size 0
-    0x84,  // Size of copy: upper bits (512 - 4 + 17 = 525)
-    0x0D,  // Size of copy: lower bits
-    0x04,  // Address of COPY
-    0x03,  // VCD_ADD size 2
+    '\x13',  // VCD_COPY mode VCD_SELF size 0
+    '\x84',  // Size of copy: upper bits (512 - 4 + 17 = 525)
+    '\x0D',  // Size of copy: lower bits
+    '\x04',  // Address of COPY
+    '\x03',  // VCD_ADD size 2
     // Data for ADD (length 2)
-    0x1B, 0x3D,
-    0x3F,  // VCD_COPY mode VCD_NEAR(0) size 15
-    0x84,  // Address of copy: upper bits (525 + 2 = 527)
-    0x0F,  // Address of copy: lower bits
-    0x02,  // VCD_ADD size 1
+    '\x1B', '\x3D',
+    '\x3F',  // VCD_COPY mode VCD_NEAR(0) size 15
+    '\x84',  // Address of copy: upper bits (525 + 2 = 527)
+    '\x0F',  // Address of copy: lower bits
+    '\x02',  // VCD_ADD size 1
     // Data for ADD (length 1)
-    0x1C,
-    0x4F,  // VCD_COPY mode VCD_NEAR(1) size 15
-    0x10,  // Address of copy
-    0x02,  // VCD_ADD size 1
+    '\x1C',
+    '\x4F',  // VCD_COPY mode VCD_NEAR(1) size 15
+    '\x10',  // Address of copy
+    '\x02',  // VCD_ADD size 1
     // Data for ADD (length 1)
-    0x2C,
-    0x53,  // VCD_COPY mode VCD_NEAR(2) size 0
-    0x87,  // Size of copy: upper bits (256 * 4 - 51 = 973)
-    0x4D,  // Size of copy: lower bits
-    0x10   // Address of copy
+    '\x2C',
+    '\x53',  // VCD_COPY mode VCD_NEAR(2) size 0
+    '\x87',  // Size of copy: upper bits (256 * 4 - 51 = 973)
+    '\x4D',  // Size of copy: lower bits
+    '\x10'   // Address of copy
   };
 
 // This is similar to VCDiffInterleavedDecoderTest, but uses the custom code
@@ -883,20 +883,20 @@ const char VCDiffCustomCodeTableDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x74,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of dictionary
+    '\x74',  // Length of the delta encoding
     FirstByteOfStringLength(kExpectedTarget),  // Size of the target window
     SecondByteOfStringLength(kExpectedTarget),
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs (unused)
-    0x6E,  // length of interleaved section
-    0x00   // length of addresses for COPYs (unused)
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs (unused)
+    '\x6E',  // length of interleaved section
+    '\x00'   // length of addresses for COPYs (unused)
   };
 
 const char VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
-    0x22,  // VCD_COPY mode VCD_SELF, size 28
-    0x00,  // Address of COPY: Start of dictionary
-    0x12,  // VCD_ADD size 61
+    '\x22',  // VCD_COPY mode VCD_SELF, size 28
+    '\x00',  // Address of COPY: Start of dictionary
+    '\x12',  // VCD_ADD size 61
     // Data for ADD (length 61)
     ' ', 'I', ' ', 'h', 'a', 'v', 'e', ' ', 's', 'a', 'i', 'd', ' ',
     'i', 't', ' ', 't', 'w', 'i', 'c', 'e', ':', '\n',
@@ -904,20 +904,20 @@ const char VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
     'a', 'l', 'o', 'n', 'e', ' ', 's', 'h', 'o', 'u', 'l', 'd', ' ',
     'e', 'n', 'c', 'o', 'u', 'r', 'a', 'g', 'e', ' ',
     't', 'h', 'e', ' ', 'c', 'r', 'e', 'w', '.', '\n',
-    0x32,  // VCD_COPY mode VCD_HERE, size 44
-    0x58,  // HERE mode address (27+61 back from here_address)
-    0xBF,  // VCD_ADD size 2 + VCD_COPY mode NEAR(0), size 5
+    '\x32',  // VCD_COPY mode VCD_HERE, size 44
+    '\x58',  // HERE mode address (27+61 back from here_address)
+    '\xBF',  // VCD_ADD size 2 + VCD_COPY mode NEAR(0), size 5
     // Data for ADDs: 2nd section (length 2)
     'h', 'r',
-    0x2D,  // NEAR(0) mode address (45 after prior address)
-    0x0A,  // VCD_ADD size 9
+    '\x2D',  // NEAR(0) mode address (45 after prior address)
+    '\x0A',  // VCD_ADD size 9
     // Data for ADDs: 3rd section (length 9)
     'W', 'h', 'a', 't', ' ',
     'I', ' ', 't', 'e',
-    0x03,  // VCD_RUN size 2
+    '\x03',  // VCD_RUN size 2
     // Data for RUN: 4th section (length 1)
     'l',
-    0x11,  // VCD_ADD size 27
+    '\x11',  // VCD_ADD size 27
     // Data for ADD: 4th section (length 27)
     ' ', 'y', 'o', 'u', ' ',
     't', 'h', 'r', 'e', 'e', ' ', 't', 'i', 'm', 'e', 's', ' ', 'i', 's', ' ',
@@ -926,8 +926,8 @@ const char VCDiffCustomCodeTableDecoderTest::kWindowBody[] = {
 
 VCDiffCustomCodeTableDecoderTest::VCDiffCustomCodeTableDecoderTest() {
   delta_file_header_.assign(kFileHeader, sizeof(kFileHeader));
-  delta_file_header_.push_back(0x01);  // NEAR cache size (custom)
-  delta_file_header_.push_back(0x06);  // SAME cache size (custom)
+  delta_file_header_.push_back('\x01');  // NEAR cache size (custom)
+  delta_file_header_.push_back('\x06');  // SAME cache size (custom)
   delta_file_header_.append(kEncodedCustomCodeTable,
                             sizeof(kEncodedCustomCodeTable));
   delta_window_header_.assign(kWindowHeader, sizeof(kWindowHeader));

--- a/src/vcdecoder5_test.cc
+++ b/src/vcdecoder5_test.cc
@@ -33,23 +33,23 @@ class VCDiffLargeTargetTest : public VCDiffDecoderTest {
 };
 
 const char VCDiffLargeTargetTest::kLargeRunWindow[] = {
-    0x00,  // Win_Indicator: no source segment
-    0x0E,  // Length of the delta encoding
-    0xA0,  // Size of the target window (0x4000000)
-    0x80,  // Size of the target window cont'd
-    0x80,  // Size of the target window cont'd
-    0x00,  // Size of the target window cont'd
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs
-    0x06,  // length of instructions section
-    0x00,  // length of addresses for COPYs
+    '\x00',  // Win_Indicator: no source segment
+    '\x0E',  // Length of the delta encoding
+    '\xA0',  // Size of the target window (0x4000000)
+    '\x80',  // Size of the target window cont'd
+    '\x80',  // Size of the target window cont'd
+    '\x00',  // Size of the target window cont'd
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs
+    '\x06',  // length of instructions section
+    '\x00',  // length of addresses for COPYs
     // Interleaved segment
-    0x00,  // VCD_RUN size 0
-    0xA0,  // Size of RUN (0x4000000)
-    0x80,  // Size of RUN cont'd
-    0x80,  // Size of RUN cont'd
-    0x00,  // Size of RUN cont'd
-    0xBE,  // Data for RUN
+    '\x00',  // VCD_RUN size 0
+    '\xA0',  // Size of RUN (0x4000000)
+    '\x80',  // Size of RUN cont'd
+    '\x80',  // Size of RUN cont'd
+    '\x00',  // Size of RUN cont'd
+    '\xBE',  // Data for RUN
 };
 
 VCDiffLargeTargetTest::VCDiffLargeTargetTest() {

--- a/src/vcdecoder_test.cc
+++ b/src/vcdecoder_test.cc
@@ -24,19 +24,19 @@
 namespace open_vcdiff {
 
 const char VCDiffDecoderTest::kStandardFileHeader[] = {
-    0xD6,  // 'V' | 0x80
-    0xC3,  // 'C' | 0x80
-    0xC4,  // 'D' | 0x80
-    0x00,  // Draft standard version number
-    0x00   // Hdr_Indicator: no custom code table, no compression
+    '\xD6',  // 'V' | '\x80'
+    '\xC3',  // 'C' | '\x80'
+    '\xC4',  // 'D' | '\x80'
+    '\x00',  // Draft standard version number
+    '\x00'   // Hdr_Indicator: no custom code table, no compression
   };
 
 const char VCDiffDecoderTest::kInterleavedFileHeader[] = {
-    0xD6,  // 'V' | 0x80
-    0xC3,  // 'C' | 0x80
-    0xC4,  // 'D' | 0x80
+    '\xD6',  // 'V' | '\x80'
+    '\xC3',  // 'C' | '\x80'
+    '\xC4',  // 'D' | '\x80'
     'S',   // SDCH version code
-    0x00   // Hdr_Indicator: no custom code table, no compression
+    '\x00'   // Hdr_Indicator: no custom code table, no compression
   };
 
 const char VCDiffDecoderTest::kDictionary[] =
@@ -101,7 +101,7 @@ void VCDiffDecoderTest::ComputeAndAddChecksum() {
 // (0x7FFFFFFF) at the given offset in the delta window.
 void VCDiffDecoderTest::WriteMaxVarintAtOffset(int offset,
                                                int bytes_to_replace) {
-  static const char kMaxVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0x7F };
+  static const char kMaxVarint[] = { '\x87', '\xFF', '\xFF', '\xFF', '\x7F' };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
                       kMaxVarint,
@@ -112,7 +112,7 @@ void VCDiffDecoderTest::WriteMaxVarintAtOffset(int offset,
 // in the delta window.
 void VCDiffDecoderTest::WriteNegativeVarintAtOffset(int offset,
                                                     int bytes_to_replace) {
-  static const char kNegativeVarint[] = { 0x88, 0x80, 0x80, 0x80, 0x00 };
+  static const char kNegativeVarint[] = { '\x88', '\x80', '\x80', '\x80', '\x00' };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
                       kNegativeVarint,
@@ -123,7 +123,7 @@ void VCDiffDecoderTest::WriteNegativeVarintAtOffset(int offset,
 // at the given offset in the delta window.
 void VCDiffDecoderTest::WriteInvalidVarintAtOffset(int offset,
                                                    int bytes_to_replace) {
-  static const char kInvalidVarint[] = { 0x87, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F };
+  static const char kInvalidVarint[] = { '\x87', '\xFF', '\xFF', '\xFF', '\xFF', '\x7F' };
   delta_file_.replace(delta_file_header_.size() + offset,
                       bytes_to_replace,
                       kInvalidVarint,
@@ -136,12 +136,12 @@ bool VCDiffDecoderTest::FuzzOneByteInDeltaFile() {
     char _or;
     char _xor;
   } fuzzers[] = {
-    { 0xff, 0x80, 0x00 },
-    { 0xff, 0xff, 0x00 },
-    { 0xff, 0x00, 0x80 },
-    { 0xff, 0x00, 0xff },
-    { 0xff, 0x01, 0x00 },
-    { 0x7f, 0x00, 0x00 },
+    { '\xff', '\x80', '\x00' },
+    { '\xff', '\xff', '\x00' },
+    { '\xff', '\x00', '\x80' },
+    { '\xff', '\x00', '\xff' },
+    { '\xff', '\x01', '\x00' },
+    { '\x7f', '\x00', '\x00' },
   };
 
   for (; fuzzer_ < (sizeof(fuzzers) / sizeof(fuzzers[0])); ++fuzzer_) {
@@ -166,14 +166,14 @@ const char VCDiffStandardDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x79,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of dictionary
+    '\x79',  // Length of the delta encoding
     FirstByteOfStringLength(kExpectedTarget),  // Size of the target window
     SecondByteOfStringLength(kExpectedTarget),
-    0x00,  // Delta_indicator (no compression)
-    0x64,  // length of data for ADDs and RUNs
-    0x0C,  // length of instructions section
-    0x03  // length of addresses for COPYs
+    '\x00',  // Delta_indicator (no compression)
+    '\x64',  // length of data for ADDs and RUNs
+    '\x0C',  // length of instructions section
+    '\x03'  // length of addresses for COPYs
   };
 
 const char VCDiffStandardDecoderTest::kWindowBody[] = {
@@ -196,22 +196,22 @@ const char VCDiffStandardDecoderTest::kWindowBody[] = {
     't', 'h', 'r', 'e', 'e', ' ', 't', 'i', 'm', 'e', 's', ' ', 'i', 's', ' ',
     't', 'r', 'u', 'e', '.', '\"', '\n',
     // Instructions and sizes (length 13)
-    0x13,  // VCD_COPY mode VCD_SELF, size 0
-    0x1C,  // Size of COPY (28)
-    0x01,  // VCD_ADD size 0
-    0x3D,  // Size of ADD (61)
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x2C,  // Size of COPY (44)
-    0xCB,  // VCD_ADD size 2 + VCD_COPY mode NEAR(1), size 5
-    0x0A,  // VCD_ADD size 9
-    0x00,  // VCD_RUN size 0
-    0x02,  // Size of RUN (2)
-    0x01,  // VCD_ADD size 0
-    0x1B,  // Size of ADD (27)
+    '\x13',  // VCD_COPY mode VCD_SELF, size 0
+    '\x1C',  // Size of COPY (28)
+    '\x01',  // VCD_ADD size 0
+    '\x3D',  // Size of ADD (61)
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x2C',  // Size of COPY (44)
+    '\xCB',  // VCD_ADD size 2 + VCD_COPY mode NEAR(1), size 5
+    '\x0A',  // VCD_ADD size 9
+    '\x00',  // VCD_RUN size 0
+    '\x02',  // Size of RUN (2)
+    '\x01',  // VCD_ADD size 0
+    '\x1B',  // Size of ADD (27)
     // Addresses for COPYs (length 3)
-    0x00,  // Start of dictionary
-    0x58,  // HERE mode address for 2nd copy (27+61 back from here_address)
-    0x2D   // NEAR(1) mode address for 2nd copy (45 after prior address)
+    '\x00',  // Start of dictionary
+    '\x58',  // HERE mode address for 2nd copy (27+61 back from here_address)
+    '\x2D'   // NEAR(1) mode address for 2nd copy (45 after prior address)
   };
 
 VCDiffStandardDecoderTest::VCDiffStandardDecoderTest() {
@@ -224,22 +224,22 @@ const char VCDiffInterleavedDecoderTest::kWindowHeader[] = {
     VCD_SOURCE,  // Win_Indicator: take source from dictionary
     FirstByteOfStringLength(kDictionary),  // Source segment size
     SecondByteOfStringLength(kDictionary),
-    0x00,  // Source segment position: start of dictionary
-    0x79,  // Length of the delta encoding
+    '\x00',  // Source segment position: start of dictionary
+    '\x79',  // Length of the delta encoding
     FirstByteOfStringLength(kExpectedTarget),  // Size of the target window
     SecondByteOfStringLength(kExpectedTarget),
-    0x00,  // Delta_indicator (no compression)
-    0x00,  // length of data for ADDs and RUNs (unused)
-    0x73,  // length of interleaved section
-    0x00  // length of addresses for COPYs (unused)
+    '\x00',  // Delta_indicator (no compression)
+    '\x00',  // length of data for ADDs and RUNs (unused)
+    '\x73',  // length of interleaved section
+    '\x00'  // length of addresses for COPYs (unused)
   };
 
 const char VCDiffInterleavedDecoderTest::kWindowBody[] = {
-    0x13,  // VCD_COPY mode VCD_SELF, size 0
-    0x1C,  // Size of COPY (28)
-    0x00,  // Address of COPY: Start of dictionary
-    0x01,  // VCD_ADD size 0
-    0x3D,  // Size of ADD (61)
+    '\x13',  // VCD_COPY mode VCD_SELF, size 0
+    '\x1C',  // Size of COPY (28)
+    '\x00',  // Address of COPY: Start of dictionary
+    '\x01',  // VCD_ADD size 0
+    '\x3D',  // Size of ADD (61)
     // Data for ADD (length 61)
     ' ', 'I', ' ', 'h', 'a', 'v', 'e', ' ', 's', 'a', 'i', 'd', ' ',
     'i', 't', ' ', 't', 'w', 'i', 'c', 'e', ':', '\n',
@@ -247,23 +247,23 @@ const char VCDiffInterleavedDecoderTest::kWindowBody[] = {
     'a', 'l', 'o', 'n', 'e', ' ', 's', 'h', 'o', 'u', 'l', 'd', ' ',
     'e', 'n', 'c', 'o', 'u', 'r', 'a', 'g', 'e', ' ',
     't', 'h', 'e', ' ', 'c', 'r', 'e', 'w', '.', '\n',
-    0x23,  // VCD_COPY mode VCD_HERE, size 0
-    0x2C,  // Size of COPY (44)
-    0x58,  // HERE mode address (27+61 back from here_address)
-    0xCB,  // VCD_ADD size 2 + VCD_COPY mode NEAR(1), size 5
+    '\x23',  // VCD_COPY mode VCD_HERE, size 0
+    '\x2C',  // Size of COPY (44)
+    '\x58',  // HERE mode address (27+61 back from here_address)
+    '\xCB',  // VCD_ADD size 2 + VCD_COPY mode NEAR(1), size 5
     // Data for ADDs: 2nd section (length 2)
     'h', 'r',
-    0x2D,  // NEAR(1) mode address (45 after prior address)
-    0x0A,  // VCD_ADD size 9
+    '\x2D',  // NEAR(1) mode address (45 after prior address)
+    '\x0A',  // VCD_ADD size 9
     // Data for ADDs: 3rd section (length 9)
     'W', 'h', 'a', 't', ' ',
     'I', ' ', 't', 'e',
-    0x00,  // VCD_RUN size 0
-    0x02,  // Size of RUN (2)
+    '\x00',  // VCD_RUN size 0
+    '\x02',  // Size of RUN (2)
     // Data for RUN: 4th section (length 1)
     'l',
-    0x01,  // VCD_ADD size 0
-    0x1B,  // Size of ADD (27)
+    '\x01',  // VCD_ADD size 0
+    '\x1B',  // Size of ADD (27)
     // Data for ADD: 4th section (length 27)
     ' ', 'y', 'o', 'u', ' ',
     't', 'h', 'r', 'e', 'e', ' ', 't', 'i', 'm', 'e', 's', ' ', 'i', 's', ' ',

--- a/src/vcencoder_test.cc
+++ b/src/vcencoder_test.cc
@@ -162,7 +162,7 @@ const char VCDiffEncoderTest::kJSONDiff[] =
     "\"hrice:\\nWhat I tell you three times is true.\\\"\\n\"]";
 
 // NonASCII string "foo\x128".
-const char VCDiffEncoderTest::kNonAscii[] = {102, 111, 111, 128, 0};
+const char VCDiffEncoderTest::kNonAscii[] = {'f', 'o', 'o', '\x80', '\0'};
 
 VCDiffEncoderTest::VCDiffEncoderTest()
     : hashed_dictionary_(kDictionary, sizeof(kDictionary)),
@@ -553,9 +553,9 @@ TEST_F(VCDiffEncoderTest, DictionaryBufferOverwritten) {
 // any other byte of data.
 TEST_F(VCDiffEncoderTest, DictionaryHasEmbeddedNULLs) {
   const char embedded_null_dictionary_text[] =
-      { 0x00, 0xFF, 0xFE, 0xFD, 0x00, 0xFD, 0xFE, 0xFF, 0x00, 0x03 };
+      { '\x00', '\xFF', '\xFE', '\xFD', '\x00', '\xFD', '\xFE', '\xFF', '\x00', '\x03' };
   const char embedded_null_target[] =
-      { 0xFD, 0x00, 0xFD, 0xFE, 0x03, 0x00, 0x01, 0x00 };
+      { '\xFD', '\x00', '\xFD', '\xFE', '\x03', '\x00', '\x01', '\x00' };
   CHECK_EQ(10, sizeof(embedded_null_dictionary_text));
   CHECK_EQ(8, sizeof(embedded_null_target));
   HashedDictionary embedded_null_dictionary(embedded_null_dictionary_text,
@@ -585,9 +585,9 @@ TEST_F(VCDiffEncoderTest, DictionaryHasEmbeddedNULLs) {
 // any other byte of data.  No text-processing of the data should occur.
 TEST_F(VCDiffEncoderTest, DictionaryHasEmbeddedNewlines) {
   const char embedded_null_dictionary_text[] =
-      { 0x0C, 0xFF, 0xFE, 0x0C, 0x00, 0x0A, 0xFE, 0xFF, 0x00, 0x0A };
+      { '\x0C', '\xFF', '\xFE', '\x0C', '\x00', '\x0A', '\xFE', '\xFF', '\x00', '\x0A' };
   const char embedded_null_target[] =
-      { 0x0C, 0x00, 0x0A, 0xFE, 0x03, 0x00, 0x0A, 0x00 };
+      { '\x0C', '\x00', '\x0A', '\xFE', '\x03', '\x00', '\x0A', '\x00' };
   CHECK_EQ(10, sizeof(embedded_null_dictionary_text));
   CHECK_EQ(8, sizeof(embedded_null_target));
   HashedDictionary embedded_null_dictionary(embedded_null_dictionary_text,


### PR DESCRIPTION
When building with a C++11 compiler (`g++ -std=c++11` or GCC 6 by default), implicit conversion from int to char generates an error.

This patchset resolves these conversion errors.
