### PR TITLE
Fix build on some systems after #75.

### DIFF
--- a/src/decodetable.cc
+++ b/src/decodetable.cc
@@ -26,7 +26,6 @@ namespace open_vcdiff {
 
 VCDiffCodeTableReader::VCDiffCodeTableReader()
     : code_table_data_(&VCDiffCodeTableData::kDefaultCodeTableData),
-      non_default_code_table_data_(NULL),
       instructions_and_sizes_(NULL),
       instructions_and_sizes_end_(NULL),
       last_instruction_start_(NULL),


### PR DESCRIPTION
On some platforms (but not all, including the one I tested this on) we
now get:

    src/decodetable.cc:29:7: error: call to
    constructor of 'std::unique_ptr<VCDiffCodeTableData>' is ambiguous
          non_default_code_table_data_(NULL),
          ^                            ~~~~
    libcxx/include/memory:2488:49:
    note: candidate constructor
        _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR unique_ptr(nullptr_t)
    _NOEXCEPT
                                                    ^
    libc++/libcxx/include/memory:2494:40:
    note: candidate constructor
        _LIBCPP_INLINE_VISIBILITY explicit unique_ptr(pointer __p) _NOEXCEPT
                                           ^
    libcxx/include/memory:2515:31:
    note: candidate constructor
        _LIBCPP_INLINE_VISIBILITY unique_ptr(unique_ptr&& __u) _NOEXCEPT
                                  ^
    libc++/libcxx/include/memory:2459:29:
    note: candidate constructor (the implicit copy constructor) has been
    implicitly deleted
    class _LIBCPP_TYPE_VIS_ONLY unique_ptr
                                ^

Just use the default ctor, which initializes both auto_ptr and
unique_ptr to null.


Sorry about the churn!