### PR TITLE
Allow not copying the dictionary

### DIFF
--- a/src/google/vcencoder.h
+++ b/src/google/vcencoder.h
@@ -38,7 +38,8 @@ class CodeTableWriterInterface;
 class HashedDictionary {
  public:
   HashedDictionary(const char* dictionary_contents,
-                   size_t dictionary_size);
+                   size_t dictionary_size,
+                   bool copy = true);
   ~HashedDictionary();
 
   // Init() must be called before using the HashedDictionary as an argument

--- a/src/vcdiffengine.cc
+++ b/src/vcdiffengine.cc
@@ -23,20 +23,21 @@
 
 namespace open_vcdiff {
 
-VCDiffEngine::VCDiffEngine(const char* dictionary, size_t dictionary_size)
+VCDiffEngine::VCDiffEngine(const char* dictionary, size_t dictionary_size, bool copy)
     // If dictionary_size == 0, then dictionary could be NULL.  Guard against
     // using a NULL value.
-    : dictionary_((dictionary_size > 0) ? new char[dictionary_size] : ""),
+    : dictionary_((dictionary_size > 0) ? (copy ? new char[dictionary_size] : dictionary) : ""),
+      owns_dictionary_(copy),
       dictionary_size_(dictionary_size),
       hashed_dictionary_(NULL) {
-  if (dictionary_size > 0) {
+  if (dictionary_size > 0 && copy) {
     memcpy(const_cast<char*>(dictionary_), dictionary, dictionary_size);
   }
 }
 
 VCDiffEngine::~VCDiffEngine() {
   delete hashed_dictionary_;
-  if (dictionary_size_ > 0) {
+  if (dictionary_size_ > 0 && owns_dictionary_) {
     delete[] dictionary_;
   }
 }

--- a/src/vcdiffengine.h
+++ b/src/vcdiffengine.h
@@ -37,7 +37,7 @@ class VCDiffEngine {
   // aligned on block boundaries in the dictionary text.
   static const size_t kMinimumMatchSize = 32;
 
-  VCDiffEngine(const char* dictionary, size_t dictionary_size);
+  VCDiffEngine(const char* dictionary, size_t dictionary_size, bool copy = true);
 
   ~VCDiffEngine();
 
@@ -106,6 +106,8 @@ class VCDiffEngine {
                              CodeTableWriterInterface* coder) const;
 
   const char* dictionary_;  // A copy of the dictionary contents
+
+  bool owns_dictionary_;
 
   const size_t dictionary_size_;
 

--- a/src/vcencoder.cc
+++ b/src/vcencoder.cc
@@ -57,8 +57,9 @@ CodeTableWriterInterface* create_writer(
 }  // namespace
 
 HashedDictionary::HashedDictionary(const char* dictionary_contents,
-                                   size_t dictionary_size)
-    : engine_(new VCDiffEngine(dictionary_contents, dictionary_size)) { }
+                                   size_t dictionary_size,
+                                   bool copy)
+    : engine_(new VCDiffEngine(dictionary_contents, dictionary_size, copy)) { }
 
 HashedDictionary::~HashedDictionary() { delete engine_; }
 


### PR DESCRIPTION
For large dictionary files, the documentation recommends simply using `mmap` to open them. This works, however as internally open-vcdiff always copies this data into the `VCDiffEngine` immediately, the full file has to be present in memory, without being able to take advantage of the kernel's smart caching. This can easily lead to OOM for large files.

The change here is fairly minor, essentially it just allows to explicitly specify that the data does not need to be copied and to assume that its lifetime is sufficient.